### PR TITLE
Updating to electron 1.8.1

### DIFF
--- a/desktop.js
+++ b/desktop.js
@@ -4,12 +4,12 @@
 
 $(function () {
   var compiler = require('squiffy/compiler.js');
-  var shell = require('shell');
+  var remote = require('electron').remote;
+  var shell = remote.shell;
   var path = require('path');
-  var remote = require('remote');
-  var dialog = remote.require('dialog');
+  var dialog = remote.dialog;
   var fs = require('fs');
-  var clipboard = require('clipboard');
+  var clipboard = remote.clipboard;
   var storage = require('./storage.js');
 
   var packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json')).toString());

--- a/main.js
+++ b/main.js
@@ -1,12 +1,16 @@
 /* global __dirname */
 /* global process */
 
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
+var electron = require('electron');
+var app = electron.app;  // Module to control application life.
+var BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
 var storage = require('./storage');
 
 // Report crashes to our server.
-require('crash-reporter').start();
+electron.crashReporter.start({
+    companyName: "textadventure.co.uk",
+    submitURL: "https://github.com/textadventures/squiffy-editor/issues",
+});
 
 var argv = process.argv;
 
@@ -53,9 +57,9 @@ var init = function() {
   mainWindow.openFile = openFile;
 
   // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/desktop.html');
+  mainWindow.loadURL('file://' + __dirname + '/desktop.html');
   
-  mainWindow.on('close', function () {
+  mainWindow.on('close', function() {
     var bounds = mainWindow.getBounds(); 
     storage.set('lastWindowState', {
       x: bounds.x,
@@ -64,6 +68,7 @@ var init = function() {
       height: bounds.height,
       maximized: mainWindow.isMaximized()
     });
+    mainWindow.destroy();
   });
 
   // Emitted when the window is closed.

--- a/menu.js
+++ b/menu.js
@@ -1,6 +1,6 @@
 (function () {
-  var remote = require('remote');
-  var app = remote.require('app');
+  var remote = require('electron').remote;
+  var app = remote.app;
   window.menuClick = window.menuClick || {};
   
   var fileNew = function () {
@@ -201,6 +201,14 @@
             label: 'Replace',
             accelerator: 'Alt+Command+F',
             click: editReplace
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: 'Settings',
+            accelerator: null,
+            click: settings
           }
         ]
       },
@@ -353,6 +361,14 @@
             label: '&Replace',
             accelerator: 'Ctrl+H',
             click: editReplace
+          },
+          {
+            type: 'separator'
+          },
+          {
+            label: 'Settings',
+            accelerator: null,
+            click: settings
           }
         ]
       },
@@ -409,7 +425,7 @@
     ];
   }
 
-  var Menu = remote.require('menu');
+  var Menu = remote.Menu;
 
   menu = Menu.buildFromTemplate(template);
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "del": "^2.2.0",
     "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.36.2",
+    "electron": "^1.8.1",
     "finalhandler": "^0.4.0",
     "gulp": "^3.9.1",
     "gulp-install": "^0.6.0",
@@ -27,7 +27,7 @@
     "jshint-stylish": "^2.1.0",
     "plist": "^1.2.0",
     "serve-static": "^1.10.0",
-	"jquery": "~2.1.4"
+    "jquery": "~2.1.4"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.5"

--- a/storage.js
+++ b/storage.js
@@ -3,11 +3,10 @@
 var app;
 
 try {
-  app = require('app'); 
+  app = require('electron').remote.app; 
 }
 catch (e) {
-  var remote = require('remote');
-  app = remote.require('app');
+  app = require('electron').app; 
 }
  
 var fs = require('fs');


### PR DESCRIPTION
Electron is configured in squiffy-editor for version 0.36.2. That also involves isue #11, in which characters are rendered as boxes in the file dialogs.
This pull request upgrades electron up to 1.8.1, which is the last stable version at the time of writing (dec 2017). A few minor changes had to be done, since instead of require app, you have to require electron and then obtain app.
